### PR TITLE
Added SPHostName to QueuedSharfePointEvent, added GetRealmFromTargetU…

### DIFF
--- a/AzureFunctionsForSharePoint.Common/QueuedSharePointEvent.cs
+++ b/AzureFunctionsForSharePoint.Common/QueuedSharePointEvent.cs
@@ -16,6 +16,10 @@ namespace AzureFunctionsForSharePoint.Common
         /// </summary>
         public string AppWebUrl { get; set; }
         /// <summary>
+        /// The host name of the SharePoint tenancy, this is used to access host webs for hybrid solutions with App Webs
+        /// </summary>
+        public string SPHostName { get; set; }
+        /// <summary>
         /// Security access token for the app-only identity
         /// </summary>
         public string AppAccessToken { get; set; }

--- a/AzureFunctionsForSharePoint.Common/TokenHelper.cs
+++ b/AzureFunctionsForSharePoint.Common/TokenHelper.cs
@@ -397,6 +397,59 @@ namespace AzureFunctionsForSharePoint.Common
         {
             return TextEncoding.GetString(DecodeBytes(arg));
         }
+
+        /// <summary>
+        /// Get authentication realm from SharePoint
+        /// </summary>
+        /// <param name="targetApplicationUri">Url of the target SharePoint site</param>
+        /// <returns>String representation of the realm GUID</returns>
+        public static string GetRealmFromTargetUrl(Uri targetApplicationUri)
+        {
+            WebRequest request = WebRequest.Create(targetApplicationUri + "/_vti_bin/client.svc");
+            request.Headers.Add("Authorization: Bearer ");
+
+            try
+            {
+                using (request.GetResponse())
+                {
+                }
+            }
+            catch (WebException e)
+            {
+                if (e.Response == null)
+                {
+                    return null;
+                }
+
+                string bearerResponseHeader = e.Response.Headers["WWW-Authenticate"];
+                if (string.IsNullOrEmpty(bearerResponseHeader))
+                {
+                    return null;
+                }
+
+                const string bearer = "Bearer realm=\"";
+                int bearerIndex = bearerResponseHeader.IndexOf(bearer, StringComparison.Ordinal);
+                if (bearerIndex < 0)
+                {
+                    return null;
+                }
+
+                int realmIndex = bearerIndex + bearer.Length;
+
+                if (bearerResponseHeader.Length >= realmIndex + 36)
+                {
+                    string targetRealm = bearerResponseHeader.Substring(realmIndex, 36);
+
+                    Guid realmGuid;
+
+                    if (Guid.TryParse(targetRealm, out realmGuid))
+                    {
+                        return targetRealm;
+                    }
+                }
+            }
+            return null;
+        }
     }
 
     /// <summary>

--- a/AzureFunctionsForSharePoint.Core/AzureFunctionsForSharePoint.Core.csproj
+++ b/AzureFunctionsForSharePoint.Core/AzureFunctionsForSharePoint.Core.csproj
@@ -42,9 +42,8 @@
       <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="IQAppProvisioningBaseClasses, Version=1.0.6473.24656, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\InstantQuick.SharePoint.Provisioning.1.0.6473.24656\lib\net452\IQAppProvisioningBaseClasses.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="IQAppProvisioningBaseClasses, Version=1.0.6555.22576, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\InstantQuick.SharePoint.Provisioning.1.0.6555.22576\lib\net452\IQAppProvisioningBaseClasses.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.2.0.4\lib\net45\Microsoft.Azure.KeyVault.Core.dll</HintPath>
@@ -135,8 +134,8 @@
       <HintPath>..\packages\Microsoft.SharePointOnline.CSOM.16.1.6420.1200\lib\net45\Microsoft.SharePoint.Client.WorkflowServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.8.5.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -179,9 +178,13 @@
     <Compile Include="SecurityTokens.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="AzureFunctionsForSharePoint.Core.nuspec" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AzureFunctionsForSharePoint.Common\AzureFunctionsForSharePoint.Common.csproj">

--- a/AzureFunctionsForSharePoint.Core/ContextUtility.cs
+++ b/AzureFunctionsForSharePoint.Core/ContextUtility.cs
@@ -38,7 +38,7 @@ namespace AzureFunctionsForSharePoint.Core
                 userClientContext = TokenHelper.GetClientContext(tokens.AppWebUrl, userAccessToken.AccessToken);
                 //Never! If the user hasn't got access
                 if (!ContextHasAccess(userClientContext)) return null;
-                
+
                 string accessToken = GetAppOnlyAccessToken(targetPrincipal, hostUri.Authority, tokens.Realm,
                     tokens.ClientId, clientConfig.AcsClientConfig.ClientSecret);
 
@@ -74,8 +74,9 @@ namespace AzureFunctionsForSharePoint.Core
                 var clientConfig = GetConfiguration(clientId);
                 var tokens = GetSecurityTokens(cacheKey, clientId);
                 if (tokens == null) return null;
+
                 Uri hostUri = new Uri(tokens.AppWebUrl);
-                
+
                 if (!appOnly) return GetUserAccessToken(cacheKey, tokens, hostUri, clientConfig).AccessToken;
                 return GetAppOnlyAccessToken(targetPrincipal, hostUri.Authority, tokens.Realm,
                                     tokens.ClientId, clientConfig.AcsClientConfig.ClientSecret);
@@ -83,6 +84,29 @@ namespace AzureFunctionsForSharePoint.Core
             catch (Exception ex)
             {
                 var detailedException = new Exception($"Unable to get client context for cId={clientId} cacheKey={cacheKey}", ex);
+                throw (detailedException);
+            }
+        }
+
+        /// <summary>
+        /// Gets an app only access token for a given client id
+        /// </summary>
+        /// <param name="clientId">The id of the client. This must match the client id from a SharePoint add-in manifest and a valid <see cref="ClientConfiguration"/>.</param>
+        /// <param name="realm">Tenant realm</param>
+        /// <param name="spWebUrl">The Url to SharePoint</param>
+        /// <returns>An access token string</returns>
+        public static string GetAppOnlyACSAccessTokens(string clientId, string realm, string spWebUrl)
+        {
+            try
+            {
+                var hostUri = new Uri(spWebUrl);
+                var clientConfig = GetConfiguration(clientId);
+                return GetAppOnlyAccessToken(targetPrincipal, hostUri.Authority, realm,
+                    clientId, clientConfig.AcsClientConfig.ClientSecret);
+            }
+            catch (Exception ex)
+            {
+                var detailedException = new Exception($"Unable to get client context for cId={clientId} spWebUrl={spWebUrl}", ex);
                 throw (detailedException);
             }
         }

--- a/AzureFunctionsForSharePoint.Core/SecurityTokens.cs
+++ b/AzureFunctionsForSharePoint.Core/SecurityTokens.cs
@@ -18,6 +18,10 @@ namespace AzureFunctionsForSharePoint.Core
         /// </summary>
         public string AppWebUrl { get; set; }
         /// <summary>
+        /// The host name of the SharePoint tenancy, this is used to access host webs for hybrid solutions with App Webs
+        /// </summary>
+        public string SPHostName { get; set; }
+        /// <summary>
         /// The host part of the app web URL
         /// </summary>
         public string Realm { get; set; }

--- a/AzureFunctionsForSharePoint.Core/app.config
+++ b/AzureFunctionsForSharePoint.Core/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.5.0.0" newVersion="8.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/AzureFunctionsForSharePoint.Core/packages.config
+++ b/AzureFunctionsForSharePoint.Core/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FSharp.Core" version="4.1.17" targetFramework="net452" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net452" />
-  <package id="InstantQuick.SharePoint.Provisioning" version="1.0.6473.24656" targetFramework="net452" />
+  <package id="InstantQuick.SharePoint.Provisioning" version="1.0.6555.22576" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="2.0.4" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
@@ -19,5 +19,5 @@
   <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="4.1.3" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.5.0" targetFramework="net452" />
 </packages>

--- a/AzureFunctionsForSharePoint.Functions/AzureFunctionsForSharePoint.Functions.csproj
+++ b/AzureFunctionsForSharePoint.Functions/AzureFunctionsForSharePoint.Functions.csproj
@@ -38,9 +38,8 @@
       <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="IQAppProvisioningBaseClasses, Version=1.0.6473.24656, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\InstantQuick.SharePoint.Provisioning.1.0.6473.24656\lib\net452\IQAppProvisioningBaseClasses.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="IQAppProvisioningBaseClasses, Version=1.0.6555.22576, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\InstantQuick.SharePoint.Provisioning.1.0.6555.22576\lib\net452\IQAppProvisioningBaseClasses.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.2.0.4\lib\net45\Microsoft.Azure.KeyVault.Core.dll</HintPath>
@@ -130,8 +129,8 @@
       <HintPath>..\packages\Microsoft.SharePointOnline.CSOM.16.1.6420.1200\lib\net45\Microsoft.SharePoint.Client.WorkflowServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.8.4.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.8.5.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -186,8 +185,12 @@
     <Compile Include="ValidateCredentialTokenHandler.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AzureFunctionsForSharePoint.Common\AzureFunctionsForSharePoint.Common.csproj">

--- a/AzureFunctionsForSharePoint.Functions/app.config
+++ b/AzureFunctionsForSharePoint.Functions/app.config
@@ -24,7 +24,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.4.0.0" newVersion="8.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.5.0.0" newVersion="8.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/AzureFunctionsForSharePoint.Functions/packages.config
+++ b/AzureFunctionsForSharePoint.Functions/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FSharp.Core" version="4.1.17" targetFramework="net452" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net452" />
-  <package id="InstantQuick.SharePoint.Provisioning" version="1.0.6473.24656" targetFramework="net452" />
+  <package id="InstantQuick.SharePoint.Provisioning" version="1.0.6555.22576" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="2.0.4" targetFramework="net452" />
@@ -21,5 +21,5 @@
   <package id="System.Spatial" version="5.8.2" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="4.1.3" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="8.4.0" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.5.0" targetFramework="net452" />
 </packages>

--- a/AzureFunctionsForSharePoint.Host/.gitignore
+++ b/AzureFunctionsForSharePoint.Host/.gitignore
@@ -146,7 +146,7 @@ publish/
 *.azurePubxml
 # TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
-#*.pubxml
+*.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/AzureFunctionsForSharePoint.Host/AzureFunctionsForSharePoint.Host.csproj
+++ b/AzureFunctionsForSharePoint.Host/AzureFunctionsForSharePoint.Host.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>    
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.5" />    
     <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.3" />    
-    <PackageReference Include="WindowsAzure.Storage" Version="8.4.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AzureFunctionsForSharePoint.Common\AzureFunctionsForSharePoint.Common.csproj" />
@@ -24,5 +24,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\PublishProfiles\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
…rl to TokenHelper to enable creation of client context with only a url, updated Microsoft.WindowsAzure.Storage package from 8.4 to 8.5, added GetAppOnlyACSAccessTokens to contextUtility for better support when working with both app and host webs in the same "app", added SPHostName to SecurityTokens class, now include SPHostUrl in redirect to app web so it can be referenced and used in app, event dispatch now includes required information for creating context in apps spanning both the host web and the app web, updated InstantQuick.SharePoint.Provisioning to 1.0.6555.22576.